### PR TITLE
Alter strings on "Users > Add New" page for non-super-admins

### DIFF
--- a/add-user-autocomplete.php
+++ b/add-user-autocomplete.php
@@ -74,11 +74,12 @@ class Add_User_Autocomplete {
 		switch ( $text ) {
 			case 'Email' :
 				// Use built-in WordPress string.
-				return __( 'Username' );
+				return __( 'Email or Username' );
 				break;
 
 			case 'Enter the email address of an existing user on this network to invite them to this site. That person will be sent an email asking them to confirm the invite.' :
-				return __( 'Enter the username of an existing user on this network to invite them to this site. That person will be sent an email asking them to confirm the invite.', 'add-user-autocomplete' );
+				// Use built-in WordPress string.
+				return __( 'Enter the email address or username of an existing user on this network to invite them to this site. That person will be sent an email asking them to confirm the invite.' );
 				break;
 
 			default :


### PR DESCRIPTION
Hi Boone,

On the "Users > Add New" admin page, this PR modifies the input label and description paragraph for the "Add Existing User" section to reference both emails and usernames instead of just email since your plugin allows to search both of these fields.  This is really only applicable to non-super-admins.

For some background info, read this ticket: https://github.com/hwdsbcommons/add-user-autocomplete/issues/1

Let me know if you have any questions.