### PR TITLE
wp_dequeue_script() fix and other minor fixes

### DIFF
--- a/add-user-autocomplete.php
+++ b/add-user-autocomplete.php
@@ -30,8 +30,8 @@ class Add_User_Autocomplete {
 	}
 
 	function add_admin_scripts() {
-		// Dequeue WP 3.4's autocomplete
-		wp_dequeue_script( 'user-search' );
+		// Dequeue WP's autocomplete
+		wp_dequeue_script( 'user-suggest' );
 
 		wp_enqueue_script( 'jquery.autocomplete', plugins_url() . '/add-user-autocomplete/js/jquery.autocomplete/jquery.autocomplete.js', array( 'jquery' ) );
 		wp_enqueue_script( 'add-user-autocomplete-js', plugins_url() . '/add-user-autocomplete/js/add-user-autocomplete.js', array( 'jquery', 'jquery.autocomplete' ) );

--- a/css/add-user-autocomplete.css
+++ b/css/add-user-autocomplete.css
@@ -1,5 +1,5 @@
 
-.autocomplete-w1 { background:url(img/shadow.png) no-repeat bottom right; position:absolute; top:0px; left:0px; margin:8px 0 0 6px; /* IE6 fix: */ _background:none; _margin:0; }
+.autocomplete-w1 { position:absolute; top:0px; left:0px; margin:8px 0 0 6px; /* IE6 fix: */ _background:none; _margin:0; }
 .autocomplete { border:1px solid #999; background:#FFF; cursor:default; text-align:left; max-height:350px; overflow:auto; margin:-6px 6px 6px -6px; /* IE6 specific: */ _height:350px;  _margin:0; _overflow-x:hidden; }
 .autocomplete .selected { background:#F0F0F0; }
 .autocomplete div { padding:2px 5px; white-space:nowrap; }

--- a/js/add-user-autocomplete.js
+++ b/js/add-user-autocomplete.js
@@ -10,7 +10,7 @@ jQuery(document).ready(function($) {
 	$(ainput).after('<ul id="add-to-blog-users"></ul>');
 	
 	/* Spinner */
-	$(ainput).bind('keyup',function(event){
+	$(ainput).on('keyup',function(event){
 		// Delete, backspace, 0-9, a-z
 		if( ( 45 < event.keyCode && event.keyCode < 91 ) || event.keyCode == 8 ) {
 			$(ainput).addClass('loading');


### PR DESCRIPTION
WordPress changed the `'user-search'` JS handle to `'user-suggest'` back in WordPress 3.4.0: https://core.trac.wordpress.org/ticket/20835. This is already fixed on the Commons, but wasn't backported to the main repo. See 1d0e493.

The other commits address some minor issues I just found:
- 0960193 - Stops CSS from trying to load an image that doesn't exist
- b56ee56 - Fixes a deprecated jQuery.bind() call.